### PR TITLE
Fix: make `ggml_backend_qnn_buffer_type_context` as static also

### DIFF
--- a/ggml-qnn.cpp
+++ b/ggml-qnn.cpp
@@ -3074,12 +3074,15 @@ ggml_backend_buffer_type_t ggml_backend_qnn_buffer_type(size_t device) {
         return nullptr;
     }
 
+    static ggml_backend_qnn_buffer_type_context ggml_backend_qnn_buffer_type_contexts[GGML_QNN_MAX_DEVICES];
     static ggml_backend_buffer_type ggml_backend_qnn_buffer_types[GGML_QNN_MAX_DEVICES];
 
     static bool ggml_backend_qnn_buffer_type_initialized = false;
 
     if (!ggml_backend_qnn_buffer_type_initialized) {
-        for (int i = 0; i < GGML_QNN_MAX_DEVICES; i++) {
+        for (size_t i = 0; i < GGML_QNN_MAX_DEVICES; i++) {
+            auto &context = ggml_backend_qnn_buffer_type_contexts[i];
+            context = { i, std::string(GGML_QNN_NAME) + std::to_string(i) };
             ggml_backend_qnn_buffer_types[i] = {
                 /* .iface   = */ {
                     /* .get_name         = */ ggml_backend_qnn_buffer_type_name,
@@ -3090,7 +3093,7 @@ ggml_backend_buffer_type_t ggml_backend_qnn_buffer_type(size_t device) {
                     /* .supports_backend = */ ggml_backend_qnn_buffer_type_supports_backend,
                     /* .is_host          = */ ggml_backend_qnn_buffer_is_host
                 },
-                /* .context = */ new ggml_backend_qnn_buffer_type_context { device, GGML_QNN_NAME + std::to_string(device) },
+                /* .context = */ &context,
             };
         }
         ggml_backend_qnn_buffer_type_initialized = true;

--- a/ggml-qnn.cpp
+++ b/ggml-qnn.cpp
@@ -2709,7 +2709,8 @@ struct ggml_backend_qnn_buffer_context {
 };
 
 
-struct ggml_backend_qnn_buffer_type_context {
+struct ggml_backend_qnn_buffer_type {
+    ggml_backend_buffer_type base;
     size_t device;
     std::string name;
 };
@@ -2851,7 +2852,7 @@ static void * ggml_qnn_host_malloc(size_t n) {
 
 
 GGML_CALL static ggml_backend_buffer_t ggml_backend_qnn_buffer_type_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size) {
-    ggml_backend_qnn_buffer_type_context * buft_ctx = (ggml_backend_qnn_buffer_type_context *)buft->context;
+    ggml_backend_qnn_buffer_type * buft_ctx = (ggml_backend_qnn_buffer_type *)buft->context;
     ggml_backend_qnn_buffer_context * ctx = new ggml_backend_qnn_buffer_context(buft_ctx->device);
 
     const size_t size_page = sysconf(_SC_PAGESIZE);
@@ -3074,13 +3075,14 @@ ggml_backend_buffer_type_t ggml_backend_qnn_buffer_type(size_t device) {
         return nullptr;
     }
 
-    static ggml_backend_buffer_type ggml_backend_qnn_buffer_types[GGML_QNN_MAX_DEVICES];
+    static ggml_backend_qnn_buffer_type ggml_backend_qnn_buffer_types[GGML_QNN_MAX_DEVICES];
 
     static bool ggml_backend_qnn_buffer_type_initialized = false;
 
     if (!ggml_backend_qnn_buffer_type_initialized) {
         for (int i = 0; i < GGML_QNN_MAX_DEVICES; i++) {
-            ggml_backend_qnn_buffer_types[i] = {
+            auto &buffer_type = ggml_backend_qnn_buffer_types[i];
+            buffer_type.base = {
                 /* .iface   = */ {
                     /* .get_name         = */ ggml_backend_qnn_buffer_type_name,
                     /* .alloc_buffer     = */ ggml_backend_qnn_buffer_type_alloc_buffer,
@@ -3090,13 +3092,15 @@ ggml_backend_buffer_type_t ggml_backend_qnn_buffer_type(size_t device) {
                     /* .supports_backend = */ ggml_backend_qnn_buffer_type_supports_backend,
                     /* .is_host          = */ ggml_backend_qnn_buffer_is_host
                 },
-                /* .context = */ new ggml_backend_qnn_buffer_type_context { device, GGML_QNN_NAME + std::to_string(device) },
+                /* .context = */ &buffer_type,
             };
+            buffer_type.device = i;
+            buffer_type.name = GGML_QNN_NAME + std::to_string(i);
         }
         ggml_backend_qnn_buffer_type_initialized = true;
     }
 
-    return &ggml_backend_qnn_buffer_types[device];
+    return &ggml_backend_qnn_buffer_types[device].base;
 }
 
 


### PR DESCRIPTION
https://github.com/ggerganov/llama.cpp/pull/6869#discussion_r1631100881

From the discussion here, thought we should make the lifespan of type's context match the type iself.